### PR TITLE
Implement the concept of Spanned<Thing>

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1,5 +1,3 @@
-use nom_locate::LocatedSpan;
-
 // Defines the types in the AST for DSLX.
 pub type ParseInput<'a> = nom_locate::LocatedSpan<&'a str>;
 
@@ -73,8 +71,8 @@ pub struct RawIdentifier<'a> {
     pub name: &'a str,
 }
 
-impl<'a> From<LocatedSpan<&'a str>> for RawIdentifier<'a> {
-    fn from(span: LocatedSpan<&'a str>) -> Self {
+impl<'a> From<ParseInput<'a>> for RawIdentifier<'a> {
+    fn from(span: ParseInput<'a>) -> Self {
         RawIdentifier {
             name: span.fragment(),
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@ use nom::{
 
 pub mod ast;
 
-use ast::{FunctionSignature, Identifier, ParameterList, ParseInput, RawParameter, Span, Spanned};
+use ast::{FunctionSignature, Identifier, Parameter, ParameterList, ParseInput, Span, Spanned};
 
 /// Return type for most parsing functions: takes in ParseInput and returns the `O` type or error.
 type ParseResult<'a, O> = IResult<ParseInput<'a>, O, nom::error::Error<ParseInput<'a>>>;
@@ -76,7 +76,7 @@ pub fn parse_identifier(input: ParseInput) -> ParseResult<Identifier> {
 }
 
 /// Parses a single param, e.g., `x: u32`.
-fn parse_param(input: ParseInput) -> ParseResult<Spanned<RawParameter>> {
+fn parse_param(input: ParseInput) -> ParseResult<Parameter> {
     spanned(tuple((
         parse_identifier,
         preceded(tag_ws(":"), parse_identifier),


### PR DESCRIPTION
DRY out the `Span` that's in every data type and the span-specific logic in every parser.

- For each old struct, strip out the Span, name it `RawFoo`.
- Make a type alias for above that is `Spanned<Foo>`. This includes the Span and Foo.
- For each old parsing function, e.g. ParseIdentifier, move the logic that's in the `map` closure into a `from` function that converts the parser's intermediate result type to its final type, e.g. `Identifier`.
- Make the `spanned` parser handle the span logic in a general way.

In the future when defining a new parser:

- define a struct that has no span, `RawBar`. This holds the things that you parsed out of the text.
- make an alias for `Spanned<RawBar>` named `Bar`
- make a `from` that converts from parser intermediate values to `RawBar`
- make a parser. The top level parsing function will return `ParseResult<Bar>`. You will call `spanned(parser_guts)`, and `parser_guts` will parse out a 'parser intermediate value'.