### PR TITLE
Fix 'streaming' parsing and add unit tests

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -281,33 +281,4 @@ mod tests {
         };
         assert_eq!(parsed, expected);
     }
-
-    // // FIXME
-    // #[test]
-    // fn test_parse_param_list2() -> Result<(), String> {
-    //     let input = ParseInput::new("x: u32");
-    //     // let input = ParseInput::new(" x: u32, y: u16 ");
-    //     let expected = ParameterList {
-    //         span: Span::from(((9, 1, 10), (15, 1, 16))),
-    //         thing: vec![Parameter {
-    //             span: Span::from(((9, 1, 10), (15, 1, 16))),
-    //             thing: RawParameter {
-    //                 name: Identifier {
-    //                     span: Span::from(((9, 1, 10), (10, 1, 11))),
-    //                     thing: RawIdentifier { name: "x" },
-    //                 },
-    //                 param_type: Identifier {
-    //                     span: Span::from(((12, 1, 13), (15, 1, 16))),
-    //                     thing: RawIdentifier { name: "u32" },
-    //                 },
-    //             },
-    //         }],
-    //     };
-    //     let parsed = match parse_param_list0(input) {
-    //         Ok(foo) => foo.1,
-    //         Err(bar) => return Err(bar.to_string()),
-    //     };
-    //     assert_eq!(parsed, expected);
-    //     Ok(())
-    // }
 }


### PR DESCRIPTION
- Fix mistakes in parsing: use `complete` instead of `streaming`.
- Add unit tests
- Minor fix: use `many0`, not `many0_count`, because we never use the count.

The problem with streaming is:

> Streaming version will return a Err::Incomplete(Needed::new(1)) if the match reaches the end of input or **if there was not match**.

[source](https://docs.rs/nom/7.1.3/nom/bytes/streaming/fn.take_till.html)

Note the bold text. Implication: streaming doesn't play nicely with alternative. Our `alt` combinators fail, saying they needed more text, instead of trying the other alternative(s).
