### PR TITLE
Implement parse_literal_type and usize

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -133,24 +133,26 @@ pub enum Signedness {
 #[derive(Debug, PartialEq)]
 pub struct Usize(pub u32);
 
-/// The type of a literal (and every literal is an integer or bit array - depening on your
-/// interpretation) has a width and signedness. E.g.:
+/// The "variable length bit type" is "The most fundamental type in DSLX". It has a width (AKA
+/// length) and signedness. E.g.:
 ///
 /// `u16` is 16 bits and unsigned
 ///
 /// `s8` is 8 bits and signed
+///
+/// See <https://google.github.io/xls/dslx_reference/#bit-type>
 #[derive(Debug, PartialEq)]
-pub struct RawLiteralType {
+pub struct RawBitType {
     pub signedness: Signedness,
     /// width, in bits
     pub width: Usize,
 }
 
-pub type LiteralType = Spanned<RawLiteralType>;
+pub type BitType = Spanned<RawBitType>;
 
-impl<'a> From<(Signedness, u32)> for RawLiteralType {
+impl<'a> From<(Signedness, u32)> for RawBitType {
     fn from((signedness, width): (Signedness, u32)) -> Self {
-        RawLiteralType {
+        RawBitType {
             signedness,
             width: Usize(width),
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@
 pub mod ast;
 
 use ast::{
-    FunctionSignature, Identifier, LiteralType, Parameter, ParameterList, ParseInput, Span, Spanned,
+    BitType, FunctionSignature, Identifier, Parameter, ParameterList, ParseInput, Span, Spanned,
 };
 use nom::{
     branch::alt,
@@ -148,7 +148,7 @@ fn parse_signed_decimal(input: ParseInput) -> ParseResult<BigInt> {
 /// `s8` `s63`
 ///
 /// See <https://google.github.io/xls/dslx_reference/#bit-type>
-fn parse_bit_type_shorthand(input: ParseInput) -> ParseResult<LiteralType> {
+fn parse_bit_type_shorthand(input: ParseInput) -> ParseResult<BitType> {
     let sign = preceding_whitespace(alt((
         char('s').map(|_| Signedness::Signed),
         char('u').map(|_| Signedness::Unsigned),
@@ -168,7 +168,7 @@ mod tests {
     use num_traits::cast::FromPrimitive;
 
     use crate::ast::{
-        Parameter, RawFunctionSignature, RawIdentifier, RawLiteralType, RawParameter, Usize,
+        Parameter, RawBitType, RawFunctionSignature, RawIdentifier, RawParameter, Usize,
     };
 
     use super::*;
@@ -444,7 +444,7 @@ mod tests {
         let (_, r) = parse_bit_type_shorthand(ParseInput::new("s1")).unwrap();
         assert_eq!(
             r.thing,
-            RawLiteralType {
+            RawBitType {
                 signedness: Signedness::Signed,
                 width: Usize(1)
             }
@@ -453,7 +453,7 @@ mod tests {
         let (_, r) = parse_bit_type_shorthand(ParseInput::new("u1")).unwrap();
         assert_eq!(
             r.thing,
-            RawLiteralType {
+            RawBitType {
                 signedness: Signedness::Unsigned,
                 width: Usize(1)
             }


### PR DESCRIPTION
Building up to parsing the literals seen [here ](https://google.github.io/xls/dslx_reference/#literals)