### PR TITLE
Implement `parse_unary_expression`

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -121,7 +121,7 @@ impl<'a> From<(Identifier<'a>, ParameterList<'a>, Identifier<'a>)> for RawFuncti
     }
 }
 
-/// Indicates a signed or unsigned integer
+/// Indicates a signed or unsigned integer.
 #[derive(Debug, PartialEq)]
 pub enum Signedness {
     Signed,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,6 @@
 //!
 //! At present, the _only_ entry point is `parse_function_signature`, taking in an ast::ParseInput.
 #![feature(assert_matches)]
-
 // TODO one day when all functions in this file are used, delete below. For now, we prefer to
 // avoid spammy Github Actions notes about unused functions.
 #![allow(dead_code)]


### PR DESCRIPTION
- Implement `parse_unary_expression`
- Fix `RawExpression::Unary`, apparently we need to `Box` `Expression`.
- Begin `parse_expression`; of course this is not complete.