### PR TITLE
impl PartialOrd for RawBinaryOperator

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,5 @@ nom = "7.1.3"
 nom_locate = "4.2.0"
 num-bigint = "0.4.4"
 num-traits = "0.2.17" # This is just for testing... make it a build flag or something?
+
+itertools = "0.12.1"


### PR DESCRIPTION
* We define a partial ordering among binary operators so that we can implement precedence-aware parsing.
* Exhaustively test all comparisons.
* Add more cases to RawBinaryOperator. Will parse them in next PR.