### PR TITLE
Parse let expressions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,5 +10,5 @@ nom = "7.1.3"
 nom_locate = "4.2.0"
 num-bigint = "0.4.4"
 num-traits = "0.2.17" # This is just for testing... make it a build flag or something?
-
 itertools = "0.12.1"
+nonempty = "0.9.0"

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -95,8 +95,8 @@ pub struct RawVariableDeclaration<'a> {
     pub typ: Identifier<'a>,
 }
 
-pub type Parameter<'a> = Spanned<RawVariableDeclaration<'a>>;
-pub type ParameterList<'a> = Spanned<Vec<Parameter<'a>>>;
+pub type VariableDeclaration<'a> = Spanned<RawVariableDeclaration<'a>>;
+pub type VariableDeclarationList<'a> = Spanned<Vec<VariableDeclaration<'a>>>;
 
 impl<'a> From<(Identifier<'a>, Identifier<'a>)> for RawVariableDeclaration<'a> {
     fn from((name, typ): (Identifier<'a>, Identifier<'a>)) -> Self {
@@ -108,15 +108,21 @@ impl<'a> From<(Identifier<'a>, Identifier<'a>)> for RawVariableDeclaration<'a> {
 #[derive(Debug, PartialEq)]
 pub struct RawFunctionSignature<'a> {
     pub name: Identifier<'a>,
-    pub parameters: ParameterList<'a>,
+    pub parameters: VariableDeclarationList<'a>,
     pub result_type: Identifier<'a>,
 }
 
 pub type FunctionSignature<'a> = Spanned<RawFunctionSignature<'a>>;
 
-impl<'a> From<(Identifier<'a>, ParameterList<'a>, Identifier<'a>)> for RawFunctionSignature<'a> {
+impl<'a> From<(Identifier<'a>, VariableDeclarationList<'a>, Identifier<'a>)>
+    for RawFunctionSignature<'a>
+{
     fn from(
-        (name, parameters, result_type): (Identifier<'a>, ParameterList<'a>, Identifier<'a>),
+        (name, parameters, result_type): (
+            Identifier<'a>,
+            VariableDeclarationList<'a>,
+            Identifier<'a>,
+        ),
     ) -> Self {
         RawFunctionSignature {
             name,

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -87,17 +87,17 @@ impl<'a> From<ParseInput<'a>> for RawIdentifier {
 /// Introduces a variable with its name and type, e.g., `foo : MyType`. E.g. used in function
 /// type signature parameter lists, `let` bindings, etc.
 #[derive(Debug, PartialEq, Clone)]
-pub struct RawVariableDeclaration {
+pub struct RawBindingDecl {
     pub name: Identifier,
     pub typ: Identifier,
 }
 
-pub type VariableDecl = Spanned<RawVariableDeclaration>;
-pub type VariableDeclList = Spanned<Vec<VariableDecl>>;
+pub type BindingDecl = Spanned<RawBindingDecl>;
+pub type BindingDeclList = Spanned<Vec<BindingDecl>>;
 
-impl From<(Identifier, Identifier)> for RawVariableDeclaration {
+impl From<(Identifier, Identifier)> for RawBindingDecl {
     fn from((name, typ): (Identifier, Identifier)) -> Self {
-        RawVariableDeclaration { name, typ }
+        RawBindingDecl { name, typ }
     }
 }
 
@@ -105,14 +105,14 @@ impl From<(Identifier, Identifier)> for RawVariableDeclaration {
 #[derive(Debug, PartialEq)]
 pub struct RawFunctionSignature {
     pub name: Identifier,
-    pub parameters: VariableDeclList,
+    pub parameters: BindingDeclList,
     pub result_type: Identifier,
 }
 
 pub type FunctionSignature = Spanned<RawFunctionSignature>;
 
-impl From<(Identifier, VariableDeclList, Identifier)> for RawFunctionSignature {
-    fn from((name, parameters, result_type): (Identifier, VariableDeclList, Identifier)) -> Self {
+impl From<(Identifier, BindingDeclList, Identifier)> for RawFunctionSignature {
+    fn from((name, parameters, result_type): (Identifier, BindingDeclList, Identifier)) -> Self {
         RawFunctionSignature {
             name,
             parameters,
@@ -370,7 +370,7 @@ impl PartialOrd for RawBinaryOperator {
 /// is the expression in which the bound name is in-scope.
 #[derive(Debug, PartialEq, Clone)]
 pub struct RawLetBinding {
-    pub variable_declaration: VariableDecl,
+    pub variable_declaration: BindingDecl,
     pub value: Box<Expression>,
 }
 pub type LetBinding = Spanned<RawLetBinding>;

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -387,7 +387,17 @@ pub enum RawExpression {
     /// a binary expression, e.g. `s1:1 + s1:0`
     Binary(Box<Expression>, BinaryOperator, Box<Expression>),
 
-    Let(VariableDeclaration, Box<Expression>),
+    /// A let expression is:
+    /// * a name bound to a...
+    /// * value (i.e. expression), followed by
+    /// * an expression that (presumably) uses the bound variable
+    ///
+    /// This last is optional; when absent, the value of the let expression is `()`.
+    Let(
+        VariableDeclaration,
+        Box<Expression>,
+        Option<Box<Expression>>,
+    ),
 }
 
 impl From<Literal> for RawExpression {
@@ -414,9 +424,11 @@ impl From<(Expression, BinaryOperator, Expression)> for RawExpression {
     }
 }
 
-impl From<(VariableDeclaration, Expression)> for RawExpression {
-    fn from((var, expr): (VariableDeclaration, Expression)) -> Self {
-        RawExpression::Let(var, Box::new(expr))
+impl From<(VariableDeclaration, Expression, Option<Expression>)> for RawExpression {
+    fn from(
+        (var, bound_expr, using_expr): (VariableDeclaration, Expression, Option<Expression>),
+    ) -> Self {
+        RawExpression::Let(var, Box::new(bound_expr), using_expr.map(|x| Box::new(x)))
     }
 }
 

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -388,9 +388,8 @@ pub enum RawExpression {
     /// A literal, e.g. `s4:0b1001`
     Literal(Literal),
 
-    /// A variable, e.g. `x`. A name bound to a value (e.g. by a previous `let` expression, or
-    /// a function argument).
-    Variable(Identifier),
+    /// A name bound to a value (e.g. by a previous `let` expression, or a function argument).
+    Binding(Identifier),
 
     /// An expression that's surrounded by an open and close parentheses. The expression inside
     /// the parentheses will be evaluated with the highest precedence.
@@ -419,7 +418,7 @@ impl From<Literal> for RawExpression {
 
 impl From<Identifier> for RawExpression {
     fn from(x: Identifier) -> Self {
-        RawExpression::Variable(x)
+        RawExpression::Binding(x)
     }
 }
 

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -408,8 +408,8 @@ pub enum RawExpression {
     ///
     /// Every binding is in scope in the bindings that come after it in the vector (i.e. a
     /// binding is lexically scoped). The final expression, if present (and we expect it to
-    /// exist most of the time), can use all the bindings. When absent, the value of the let
-    /// expression is `()`.
+    /// exist most of the time, otherwise, why bother with an if expression), can use all the
+    /// bindings. When absent, the value of the let expression is `()`.
     Let(NonEmpty<LetBinding>, Option<Box<Expression>>),
 }
 

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -87,19 +87,20 @@ impl<'a> From<ParseInput<'a>> for RawIdentifier<'a> {
     }
 }
 
-/// A parameter to a function, e.g., `foo: MyType`.
+/// Introduces a variable with its name and type, e.g., `foo : MyType`. E.g. used in function
+/// type signature parameter lists, `let` bindings, etc.
 #[derive(Debug, PartialEq)]
-pub struct RawParameter<'a> {
+pub struct RawVariableDeclaration<'a> {
     pub name: Identifier<'a>,
-    pub param_type: Identifier<'a>,
+    pub typ: Identifier<'a>,
 }
 
-pub type Parameter<'a> = Spanned<RawParameter<'a>>;
+pub type Parameter<'a> = Spanned<RawVariableDeclaration<'a>>;
 pub type ParameterList<'a> = Spanned<Vec<Parameter<'a>>>;
 
-impl<'a> From<(Identifier<'a>, Identifier<'a>)> for RawParameter<'a> {
-    fn from((name, param_type): (Identifier<'a>, Identifier<'a>)) -> Self {
-        RawParameter { name, param_type }
+impl<'a> From<(Identifier<'a>, Identifier<'a>)> for RawVariableDeclaration<'a> {
+    fn from((name, typ): (Identifier<'a>, Identifier<'a>)) -> Self {
+        RawVariableDeclaration { name, typ }
     }
 }
 

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -73,16 +73,16 @@ impl From<((usize, usize, usize), (usize, usize, usize))> for Span {
 
 /// Represents a name of an entity, such as a type, variable, function, etc.
 #[derive(Debug, PartialEq)]
-pub struct RawIdentifier<'a> {
-    pub name: &'a str,
+pub struct RawIdentifier {
+    pub name: String,
 }
 
-pub type Identifier<'a> = Spanned<RawIdentifier<'a>>;
+pub type Identifier = Spanned<RawIdentifier>;
 
-impl<'a> From<ParseInput<'a>> for RawIdentifier<'a> {
+impl<'a> From<ParseInput<'a>> for RawIdentifier {
     fn from(span: ParseInput<'a>) -> Self {
         RawIdentifier {
-            name: span.fragment(),
+            name: (*span.fragment()).to_owned(),
         }
     }
 }
@@ -90,39 +90,33 @@ impl<'a> From<ParseInput<'a>> for RawIdentifier<'a> {
 /// Introduces a variable with its name and type, e.g., `foo : MyType`. E.g. used in function
 /// type signature parameter lists, `let` bindings, etc.
 #[derive(Debug, PartialEq)]
-pub struct RawVariableDeclaration<'a> {
-    pub name: Identifier<'a>,
-    pub typ: Identifier<'a>,
+pub struct RawVariableDeclaration {
+    pub name: Identifier,
+    pub typ: Identifier,
 }
 
-pub type VariableDeclaration<'a> = Spanned<RawVariableDeclaration<'a>>;
-pub type VariableDeclarationList<'a> = Spanned<Vec<VariableDeclaration<'a>>>;
+pub type VariableDeclaration = Spanned<RawVariableDeclaration>;
+pub type VariableDeclarationList = Spanned<Vec<VariableDeclaration>>;
 
-impl<'a> From<(Identifier<'a>, Identifier<'a>)> for RawVariableDeclaration<'a> {
-    fn from((name, typ): (Identifier<'a>, Identifier<'a>)) -> Self {
+impl From<(Identifier, Identifier)> for RawVariableDeclaration {
+    fn from((name, typ): (Identifier, Identifier)) -> Self {
         RawVariableDeclaration { name, typ }
     }
 }
 
 /// A function signature, e.g: `fn foo(x:u32) -> u32`.
 #[derive(Debug, PartialEq)]
-pub struct RawFunctionSignature<'a> {
-    pub name: Identifier<'a>,
-    pub parameters: VariableDeclarationList<'a>,
-    pub result_type: Identifier<'a>,
+pub struct RawFunctionSignature {
+    pub name: Identifier,
+    pub parameters: VariableDeclarationList,
+    pub result_type: Identifier,
 }
 
-pub type FunctionSignature<'a> = Spanned<RawFunctionSignature<'a>>;
+pub type FunctionSignature = Spanned<RawFunctionSignature>;
 
-impl<'a> From<(Identifier<'a>, VariableDeclarationList<'a>, Identifier<'a>)>
-    for RawFunctionSignature<'a>
-{
+impl From<(Identifier, VariableDeclarationList, Identifier)> for RawFunctionSignature {
     fn from(
-        (name, parameters, result_type): (
-            Identifier<'a>,
-            VariableDeclarationList<'a>,
-            Identifier<'a>,
-        ),
+        (name, parameters, result_type): (Identifier, VariableDeclarationList, Identifier),
     ) -> Self {
         RawFunctionSignature {
             name,

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -72,7 +72,7 @@ impl From<((usize, usize, usize), (usize, usize, usize))> for Span {
 }
 
 /// Represents a name of an entity, such as a type, variable, function, etc.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct RawIdentifier {
     pub name: String,
 }
@@ -89,7 +89,7 @@ impl<'a> From<ParseInput<'a>> for RawIdentifier {
 
 /// Introduces a variable with its name and type, e.g., `foo : MyType`. E.g. used in function
 /// type signature parameter lists, `let` bindings, etc.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct RawVariableDeclaration {
     pub name: Identifier,
     pub typ: Identifier,
@@ -386,6 +386,8 @@ pub enum RawExpression {
 
     /// a binary expression, e.g. `s1:1 + s1:0`
     Binary(Box<Expression>, BinaryOperator, Box<Expression>),
+
+    Let(VariableDeclaration, Box<Expression>),
 }
 
 impl From<Literal> for RawExpression {
@@ -409,6 +411,12 @@ impl From<(UnaryOperator, Expression)> for RawExpression {
 impl From<(Expression, BinaryOperator, Expression)> for RawExpression {
     fn from((lhs, op, rhs): (Expression, BinaryOperator, Expression)) -> Self {
         RawExpression::Binary(Box::new(lhs), op, Box::new(rhs))
+    }
+}
+
+impl From<(VariableDeclaration, Expression)> for RawExpression {
+    fn from((var, expr): (VariableDeclaration, Expression)) -> Self {
+        RawExpression::Let(var, Box::new(expr))
     }
 }
 

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -445,7 +445,7 @@ impl From<(Expression, BinaryOperator, Expression)> for RawExpression {
 
 impl From<(NonEmpty<LetBinding>, Option<Expression>)> for RawExpression {
     fn from((bindings, using_expr): (NonEmpty<LetBinding>, Option<Expression>)) -> Self {
-        RawExpression::Let(bindings, using_expr.map(|x| Box::new(x)))
+        RawExpression::Let(bindings, using_expr.map(Box::new))
     }
 }
 

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -92,8 +92,8 @@ pub struct RawVariableDeclaration {
     pub typ: Identifier,
 }
 
-pub type VariableDeclaration = Spanned<RawVariableDeclaration>;
-pub type VariableDeclarationList = Spanned<Vec<VariableDeclaration>>;
+pub type VariableDecl = Spanned<RawVariableDeclaration>;
+pub type VariableDeclList = Spanned<Vec<VariableDecl>>;
 
 impl From<(Identifier, Identifier)> for RawVariableDeclaration {
     fn from((name, typ): (Identifier, Identifier)) -> Self {
@@ -105,16 +105,14 @@ impl From<(Identifier, Identifier)> for RawVariableDeclaration {
 #[derive(Debug, PartialEq)]
 pub struct RawFunctionSignature {
     pub name: Identifier,
-    pub parameters: VariableDeclarationList,
+    pub parameters: VariableDeclList,
     pub result_type: Identifier,
 }
 
 pub type FunctionSignature = Spanned<RawFunctionSignature>;
 
-impl From<(Identifier, VariableDeclarationList, Identifier)> for RawFunctionSignature {
-    fn from(
-        (name, parameters, result_type): (Identifier, VariableDeclarationList, Identifier),
-    ) -> Self {
+impl From<(Identifier, VariableDeclList, Identifier)> for RawFunctionSignature {
+    fn from((name, parameters, result_type): (Identifier, VariableDeclList, Identifier)) -> Self {
         RawFunctionSignature {
             name,
             parameters,
@@ -372,7 +370,7 @@ impl PartialOrd for RawBinaryOperator {
 /// is the expression in which the bound name is in-scope.
 #[derive(Debug, PartialEq, Clone)]
 pub struct RawLetBinding {
-    pub variable_declaration: VariableDeclaration,
+    pub variable_declaration: VariableDecl,
     pub value: Box<Expression>,
 }
 pub type LetBinding = Spanned<RawLetBinding>;

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -381,8 +381,12 @@ pub struct ParenthesizedExpression(pub Expression);
 /// An expression (i.e. a thing that can be evaluated), e.g. `s1:1 + s1:0`.
 #[derive(Debug, PartialEq, Clone)]
 pub enum RawExpression {
-    /// a literal, e.g. `s4:0b1001`
+    /// A literal, e.g. `s4:0b1001`
     Literal(Literal),
+
+    /// A variable, e.g. `x`. A name bound to a value (e.g. by a previous `let` expression, or
+    /// a function argument).
+    Variable(Identifier),
 
     /// An expression that's surrounded by an open and close parentheses. The expression inside
     /// the parentheses will be evaluated with the highest precedence.
@@ -410,6 +414,12 @@ pub enum RawExpression {
 impl From<Literal> for RawExpression {
     fn from(x: Literal) -> Self {
         RawExpression::Literal(x)
+    }
+}
+
+impl From<Identifier> for RawExpression {
+    fn from(x: Identifier) -> Self {
+        RawExpression::Variable(x)
     }
 }
 

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -371,6 +371,13 @@ impl PartialOrd for RawBinaryOperator {
     }
 }
 
+// This struct exists to ensure that `From<Expression> for RawExpression` does not exist
+// (because instead we have `From<ParenthesizedExpression> for RawExpression`). The former was
+// bug prone: I was accidentally and unknowingly calling `from(Expression) -> RawExpression`.
+// Inside the `from` we will discard the ParenthesizedExpression 'wrapper'.
+#[derive(Debug, PartialEq, Clone)]
+pub struct ParenthesizedExpression(pub Expression);
+
 /// An expression (i.e. a thing that can be evaluated), e.g. `s1:1 + s1:0`.
 #[derive(Debug, PartialEq, Clone)]
 pub enum RawExpression {
@@ -406,8 +413,8 @@ impl From<Literal> for RawExpression {
     }
 }
 
-impl From<Expression> for RawExpression {
-    fn from(x: Expression) -> Self {
+impl From<ParenthesizedExpression> for RawExpression {
+    fn from(ParenthesizedExpression(x): ParenthesizedExpression) -> Self {
         RawExpression::Parenthesized(Box::new(x))
     }
 }

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -73,17 +73,13 @@ impl From<((usize, usize, usize), (usize, usize, usize))> for Span {
 
 /// Represents a name of an entity, such as a type, variable, function, etc.
 #[derive(Debug, PartialEq, Clone)]
-pub struct RawIdentifier {
-    pub name: String,
-}
+pub struct RawIdentifier(pub String);
 
 pub type Identifier = Spanned<RawIdentifier>;
 
 impl<'a> From<ParseInput<'a>> for RawIdentifier {
     fn from(span: ParseInput<'a>) -> Self {
-        RawIdentifier {
-            name: (*span.fragment()).to_owned(),
-        }
+        RawIdentifier((*span.fragment()).to_owned())
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,7 +87,7 @@ pub fn parse_identifier(input: ParseInput) -> ParseResult<Identifier> {
     spanned(p).parse(input)
 }
 
-/// Parses a variable declaration, e.g., `x : u32`.
+/// Parses a variable declaration, e.g., `x: u32`.
 fn parse_variable_declaration(input: ParseInput) -> ParseResult<VariableDecl> {
     spanned(tuple((
         parse_identifier,
@@ -1554,6 +1554,9 @@ mod tests {
 
     #[test]
     fn test_parse_let_expression() -> () {
+        // whitespace accepted
+        all_consuming(parse_expression(None))(ParseInput::new("let  foo : u32 = bar;")).expect("");
+
         // test the first variable decl, and the using expression
         let s = r"let a: u32 = u32:1 * u32:2;
         a & a";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -521,12 +521,12 @@ mod tests {
             p,
             Spanned {
                 span: Span::from(((1, 1, 2), (7, 1, 8))),
-                thing: RawParameter {
+                thing: RawVariableDeclaration {
                     name: Spanned {
                         span: Span::from(((1, 1, 2), (2, 1, 3))),
                         thing: RawIdentifier { name: "x" }
                     },
-                    param_type: Spanned {
+                    typ: Spanned {
                         span: Span::from(((5, 1, 6), (7, 1, 8))),
                         thing: RawIdentifier { name: "u2" }
                     }
@@ -551,12 +551,12 @@ mod tests {
                 thing: vec![
                     Spanned {
                         span: Span::from(((0, 1, 1), (6, 1, 7))),
-                        thing: RawParameter {
+                        thing: RawVariableDeclaration {
                             name: Spanned {
                                 span: Span::from(((0, 1, 1), (1, 1, 2))),
                                 thing: RawIdentifier { name: "x" }
                             },
-                            param_type: Spanned {
+                            typ: Spanned {
                                 span: Span::from(((4, 1, 5), (6, 1, 7))),
                                 thing: RawIdentifier { name: "u2" }
                             }
@@ -564,12 +564,12 @@ mod tests {
                     },
                     Spanned {
                         span: Span::from(((7, 1, 8), (13, 1, 14))),
-                        thing: RawParameter {
+                        thing: RawVariableDeclaration {
                             name: Spanned {
                                 span: Span::from(((7, 1, 8), (8, 1, 9))),
                                 thing: RawIdentifier { name: "y" }
                             },
-                            param_type: Spanned {
+                            typ: Spanned {
                                 span: Span::from(((11, 1, 12), (13, 1, 14))),
                                 thing: RawIdentifier { name: "u4" }
                             }
@@ -595,12 +595,12 @@ mod tests {
                     span: Span::from(((9, 1, 10), (15, 1, 16))),
                     thing: vec![Parameter {
                         span: Span::from(((9, 1, 10), (15, 1, 16))),
-                        thing: RawParameter {
+                        thing: RawVariableDeclaration {
                             name: Identifier {
                                 span: Span::from(((9, 1, 10), (10, 1, 11))),
                                 thing: RawIdentifier { name: "x" },
                             },
-                            param_type: Identifier {
+                            typ: Identifier {
                                 span: Span::from(((12, 1, 13), (15, 1, 16))),
                                 thing: RawIdentifier { name: "u32" },
                             },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -292,8 +292,8 @@ fn parse_unary_atomic_expression(input: ParseInput) -> ParseResult<Expression> {
             tag_ws(")"),
         )),
         spanned(parse_let_expression),
-        spanned(parse_literal),
         spanned(tuple((parse_unary_operator, parse_unary_atomic_expression))),
+        spanned(parse_literal),
     ))
     .parse(input)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -340,7 +340,7 @@ fn parse_let_expression(
     // overflows when fuzzing.
     let bindings = many1(spanned(parse_let_binding)).map(|xs| {
         let mut ys = NonEmpty::new(xs.first().unwrap().clone());
-        ys.extend(xs.iter().skip(1).cloned());
+        ys.extend(xs.into_iter().skip(1));
         ys
     });
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -287,6 +287,37 @@ fn parse_unary_atomic_expression(input: ParseInput) -> ParseResult<Expression> {
     .parse(input)
 }
 
+/// Parses a binary operator. E.g. `|`, `&`, etc.
+fn parse_binary_operator(input: ParseInput) -> ParseResult<BinaryOperator> {
+    let op = alt((
+        // These two must match before | and &
+        value(RawBinaryOperator::BooleanOr, tag("||")),
+        value(RawBinaryOperator::BooleanAnd, tag("&&")),
+        // now match | and &
+        value(RawBinaryOperator::BitwiseOr, tag("|")),
+        value(RawBinaryOperator::BitwiseAnd, tag("&")),
+        value(RawBinaryOperator::BitwiseXor, tag("^")),
+        // concatenate must match before +
+        value(RawBinaryOperator::Concatenate, tag("++")),
+        // the order of these does not matter
+        // arithmetic
+        value(RawBinaryOperator::Add, tag("+")),
+        value(RawBinaryOperator::Subtract, tag("-")),
+        value(RawBinaryOperator::Multiply, tag("*")),
+        // shift
+        value(RawBinaryOperator::ShiftRight, tag(">>")),
+        value(RawBinaryOperator::ShiftLeft, tag("<<")),
+        // compare
+        value(RawBinaryOperator::Equal, tag("==")),
+        value(RawBinaryOperator::NotEqual, tag("!=")),
+        value(RawBinaryOperator::GreaterOrEqual, tag(">=")),
+        value(RawBinaryOperator::Greater, tag(">")),
+        value(RawBinaryOperator::LessOrEqual, tag("<=")),
+        value(RawBinaryOperator::Less, tag("<")),
+    ));
+    spanned(op).parse(input)
+}
+
 /// Parses a binary operator and the expression that follows it, given the expression preceding
 /// the operator, returning all of this is a binary `Expression`.
 ///
@@ -371,37 +402,6 @@ fn parse_expression<'a>(
             }
         }
     }
-}
-
-/// Parses a binary operator. E.g. `|`, `&`, etc.
-fn parse_binary_operator(input: ParseInput) -> ParseResult<BinaryOperator> {
-    let op = alt((
-        // These two must match before | and &
-        value(RawBinaryOperator::BooleanOr, tag("||")),
-        value(RawBinaryOperator::BooleanAnd, tag("&&")),
-        // now match | and &
-        value(RawBinaryOperator::BitwiseOr, tag("|")),
-        value(RawBinaryOperator::BitwiseAnd, tag("&")),
-        value(RawBinaryOperator::BitwiseXor, tag("^")),
-        // concatenate must match before +
-        value(RawBinaryOperator::Concatenate, tag("++")),
-        // the order of these does not matter
-        // arithmetic
-        value(RawBinaryOperator::Add, tag("+")),
-        value(RawBinaryOperator::Subtract, tag("-")),
-        value(RawBinaryOperator::Multiply, tag("*")),
-        // shift
-        value(RawBinaryOperator::ShiftRight, tag(">>")),
-        value(RawBinaryOperator::ShiftLeft, tag("<<")),
-        // compare
-        value(RawBinaryOperator::Equal, tag("==")),
-        value(RawBinaryOperator::NotEqual, tag("!=")),
-        value(RawBinaryOperator::GreaterOrEqual, tag(">=")),
-        value(RawBinaryOperator::Greater, tag(">")),
-        value(RawBinaryOperator::LessOrEqual, tag("<=")),
-        value(RawBinaryOperator::Less, tag("<")),
-    ));
-    spanned(op).parse(input)
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -339,12 +339,15 @@ fn parse_binary_operator(input: ParseInput) -> ParseResult<BinaryOperator> {
 fn parse_let_expression(
     input: ParseInput,
 ) -> ParseResult<(VariableDeclaration, Expression, Option<Expression>)> {
-    // let must be followed by at least 1 whitespace
-    let let_p = terminated(tag_ws("let"), whitespace_exactly1);
-    let var_p = delimited(let_p, parse_variable_declaration, tag_ws("="));
+    let var_decl = delimited(
+        // let must be followed by at least 1 whitespace
+        tuple((tag_ws("let"), whitespace_exactly1)),
+        parse_variable_declaration,
+        tag_ws("="),
+    );
     let bound_expr = terminated(parse_expression(None), tag_ws(";"));
     let using_expr = opt(parse_expression(None));
-    tuple((var_p, bound_expr, using_expr)).parse(input)
+    tuple((var_decl, bound_expr, using_expr)).parse(input)
 }
 
 /// Parses a binary operator and the expression that follows it, given the expression preceding

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,7 +88,7 @@ pub fn parse_identifier(input: ParseInput) -> ParseResult<Identifier> {
 }
 
 /// Parses a variable declaration, e.g., `x: u32`.
-fn parse_variable_declaration(input: ParseInput) -> ParseResult<VariableDecl> {
+fn parse_variable_declaration(input: ParseInput) -> ParseResult<BindingDecl> {
     spanned(tuple((
         parse_identifier,
         preceded(tag_ws(":"), parse_identifier),
@@ -98,7 +98,7 @@ fn parse_variable_declaration(input: ParseInput) -> ParseResult<VariableDecl> {
 
 /// Parses a comma-separated list of variable declarations, e.g., `x: u32, y: MyCustomType`.
 /// Note that a trailing comma will not be matched or consumed by this function.
-fn parse_parameter_list0(input: ParseInput) -> ParseResult<VariableDeclList> {
+fn parse_parameter_list0(input: ParseInput) -> ParseResult<BindingDeclList> {
     // TODO C++ DSLX allows a single trailing comma. Parse/allow that here.
     spanned(separated_list0(tag_ws(","), parse_variable_declaration))(input)
 }
@@ -579,7 +579,7 @@ mod tests {
             p,
             Spanned {
                 span: Span::from(((1, 1, 2), (7, 1, 8))),
-                thing: RawVariableDeclaration {
+                thing: RawBindingDecl {
                     name: Spanned {
                         span: Span::from(((1, 1, 2), (2, 1, 3))),
                         thing: RawIdentifier("x".to_owned())
@@ -609,7 +609,7 @@ mod tests {
                 thing: vec![
                     Spanned {
                         span: Span::from(((0, 1, 1), (6, 1, 7))),
-                        thing: RawVariableDeclaration {
+                        thing: RawBindingDecl {
                             name: Spanned {
                                 span: Span::from(((0, 1, 1), (1, 1, 2))),
                                 thing: RawIdentifier("x".to_owned())
@@ -622,7 +622,7 @@ mod tests {
                     },
                     Spanned {
                         span: Span::from(((7, 1, 8), (13, 1, 14))),
-                        thing: RawVariableDeclaration {
+                        thing: RawBindingDecl {
                             name: Spanned {
                                 span: Span::from(((7, 1, 8), (8, 1, 9))),
                                 thing: RawIdentifier("y".to_owned())
@@ -649,11 +649,11 @@ mod tests {
                     span: Span::from(((3, 1, 4), (8, 1, 9))),
                     thing: RawIdentifier("add_1".to_owned()),
                 },
-                parameters: VariableDeclList {
+                parameters: BindingDeclList {
                     span: Span::from(((9, 1, 10), (15, 1, 16))),
-                    thing: vec![VariableDecl {
+                    thing: vec![BindingDecl {
                         span: Span::from(((9, 1, 10), (15, 1, 16))),
-                        thing: RawVariableDeclaration {
+                        thing: RawBindingDecl {
                             name: Identifier {
                                 span: Span::from(((9, 1, 10), (10, 1, 11))),
                                 thing: RawIdentifier("x".to_owned()),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,7 +84,7 @@ pub fn parse_identifier(input: ParseInput) -> ParseResult<Identifier> {
 }
 
 /// Parses a single param, e.g., `x: u32`.
-fn parse_param(input: ParseInput) -> ParseResult<Parameter> {
+fn parse_param(input: ParseInput) -> ParseResult<VariableDeclaration> {
     spanned(tuple((
         parse_identifier,
         preceded(tag_ws(":"), parse_identifier),
@@ -94,7 +94,7 @@ fn parse_param(input: ParseInput) -> ParseResult<Parameter> {
 
 /// Parses a comma-separated list of params, e.g., `x: u32, y: MyCustomType`.
 /// Note that a trailing comma will not be matched or consumed by this function.
-fn parse_param_list0(input: ParseInput) -> ParseResult<ParameterList> {
+fn parse_param_list0(input: ParseInput) -> ParseResult<VariableDeclarationList> {
     spanned(separated_list0(tag_ws(","), parse_param))(input)
 }
 
@@ -591,9 +591,9 @@ mod tests {
                     span: Span::from(((3, 1, 4), (8, 1, 9))),
                     thing: RawIdentifier { name: "add_1" },
                 },
-                parameters: ParameterList {
+                parameters: VariableDeclarationList {
                     span: Span::from(((9, 1, 10), (15, 1, 16))),
-                    thing: vec![Parameter {
+                    thing: vec![VariableDeclaration {
                         span: Span::from(((9, 1, 10), (15, 1, 16))),
                         thing: RawVariableDeclaration {
                             name: Identifier {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1566,7 +1566,6 @@ mod tests {
 
     #[test]
     fn test_parse_let_expression() -> () {
-        // TODO currently broken because identifiers are not allowed in expressions.
         let s = r"let a: u32 = u32:1 * u32:2;
         a & a";
         let (vd, bound_expr, using_expr) = expression_is_let(
@@ -1581,18 +1580,18 @@ mod tests {
         let (_, op, _) = expression_is_binary(*using_expr.unwrap());
         assert_eq!(op, RawBinaryOperator::BitwiseAnd);
 
-        let s = r"let b: u32 = u32:1 + u32:2;
-        let c: u32 = b + u32:3;
-        c";
+        let s = r"let b: u16 = u16:1 + u16:2;
+        let c: u16 = u16:3;";
         let (vd, bound_expr, using_expr) = expression_is_let(
             all_consuming(parse_expression(None))(ParseInput::new(s))
                 .unwrap()
                 .1,
         );
         assert_eq!(vd.name.thing.name, "b");
-        assert_eq!(vd.typ.thing.name, "u32");
+        assert_eq!(vd.typ.thing.name, "u16");
         let (_, op, _) = expression_is_binary(*bound_expr);
         assert_eq!(op, RawBinaryOperator::Add);
-        expression_is_let(*using_expr.unwrap()); // we won't inspect the `let c...` expression any further
+        let (_vd, _bound_exprr, using_expr) = expression_is_let(*using_expr.unwrap());
+        assert_eq!(using_expr, None);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1552,4 +1552,36 @@ mod tests {
         assert_eq!((*lhs).span, Span::from(((1, 1, 2), (12, 1, 13))));
         assert_eq!((*rhs).span, Span::from(((15, 1, 16), (26, 1, 27))));
     }
+
+    #[test]
+    fn test_parse_let_expression() -> () {
+        // TODO currently broken because identifiers are not allowed in expressions.
+        let s = r"let a: u32 = u32:1 * u32:2;
+        a & a";
+        let (vd, bound_expr, using_expr) = expression_is_let(
+            all_consuming(parse_expression(None))(ParseInput::new(s))
+                .unwrap()
+                .1,
+        );
+        assert_eq!(vd.name.thing.name, "a");
+        assert_eq!(vd.typ.thing.name, "u32");
+        let (_, op, _) = expression_is_binary(*bound_expr);
+        assert_eq!(op, RawBinaryOperator::Multiply);
+        let (_, op, _) = expression_is_binary(*using_expr.unwrap());
+        assert_eq!(op, RawBinaryOperator::BitwiseAnd);
+
+        let s = r"let b: u32 = u32:1 + u32:2;
+        let c: u32 = b + u32:3;
+        c";
+        let (vd, bound_expr, using_expr) = expression_is_let(
+            all_consuming(parse_expression(None))(ParseInput::new(s))
+                .unwrap()
+                .1,
+        );
+        assert_eq!(vd.name.thing.name, "b");
+        assert_eq!(vd.typ.thing.name, "u32");
+        let (_, op, _) = expression_is_binary(*bound_expr);
+        assert_eq!(op, RawBinaryOperator::Add);
+        expression_is_let(*using_expr.unwrap()); // we won't inspect the `let c...` expression any further
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -328,6 +328,11 @@ fn parse_let_expression(
         tag_ws("="),
     );
     let bound_expr = terminated(parse_expression(None), tag_ws(";"));
+    // TODO consider a non-recursive method parsing of `let`, because
+    // "Less recursive implementation so you get less stack overflows when fuzzing"
+    // For example, consider greedily parsing an (uninterrupted) sequence of let expressions,
+    // followed by 0 or 1 non-let expressions. We could still stick them into a recursive
+    // Expression data structure without stack overflowing.
     let using_expr = opt(parse_expression(None));
     tuple((var_decl, bound_expr, using_expr)).parse(input)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1556,6 +1556,7 @@ mod tests {
 
     #[test]
     fn test_parse_let_expression() -> () {
+        // test the first variable decl, and the using expression
         let s = r"let a: u32 = u32:1 * u32:2;
         a & a";
         let (bindings, using_expr) = expression_is_let(
@@ -1576,6 +1577,7 @@ mod tests {
         let (_, op, _) = expression_is_binary(*using_expr.unwrap());
         assert_eq!(op, RawBinaryOperator::BitwiseAnd);
 
+        // test two bindings, and no using expression.
         let s = r"let b: u16 = u16:1 + u16:2;
         let c: u8 = u16:3;";
         let (bindings, using_expr) = expression_is_let(
@@ -1584,11 +1586,11 @@ mod tests {
                 .1,
         );
         assert_eq!(
-            bindings.first().thing.variable_declaration.thing.name.thing,
+            bindings[0].thing.variable_declaration.thing.name.thing,
             RawIdentifier("b".to_owned())
         );
         assert_eq!(
-            bindings.first().thing.variable_declaration.thing.typ.thing,
+            bindings[0].thing.variable_declaration.thing.typ.thing,
             RawIdentifier("u16".to_owned())
         );
         assert_eq!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,10 +15,8 @@ use ast::*;
 use nom::{
     branch::alt,
     bytes::complete::{tag, take_while, take_while1},
-    character::complete::hex_digit1,
-    character::complete::{alpha1, alphanumeric1, char, digit1, satisfy},
-    combinator::verify,
-    combinator::{flat_map, map_opt, map_res, not, opt, peek, recognize, success, value},
+    character::complete::{alpha1, alphanumeric1, char, digit1, hex_digit1, satisfy},
+    combinator::{flat_map, map_opt, map_res, not, opt, peek, recognize, success, value, verify},
     multi::{many0, many1, separated_list0, separated_list1},
     sequence::{delimited, pair, preceded, terminated, tuple},
     IResult, Parser,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -357,7 +357,7 @@ fn parse_unary_atomic_expression(input: ParseInput) -> ParseResult<Expression> {
     alt((
         spanned(delimited(
             tag("("),
-            parse_expression(None).map(|e| ParenthesizedExpression(e)),
+            parse_expression(None).map(ParenthesizedExpression),
             tag_ws(")"),
         )),
         spanned(parse_let_expression),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -543,9 +543,7 @@ mod tests {
                     unsafe { LocatedSpan::new_from_raw_offset(10, 1, "! ", (),) },
                     Spanned {
                         span: Span::from(((1, 1, 2), (10, 1, 11))),
-                        thing: RawIdentifier {
-                            name: "_foo23Bar".to_owned()
-                        }
+                        thing: RawIdentifier("_foo23Bar".to_owned())
                     }
                 ),
             ),
@@ -572,15 +570,11 @@ mod tests {
                 thing: RawVariableDeclaration {
                     name: Spanned {
                         span: Span::from(((1, 1, 2), (2, 1, 3))),
-                        thing: RawIdentifier {
-                            name: "x".to_owned()
-                        }
+                        thing: RawIdentifier("x".to_owned())
                     },
                     typ: Spanned {
                         span: Span::from(((5, 1, 6), (7, 1, 8))),
-                        thing: RawIdentifier {
-                            name: "u2".to_owned()
-                        }
+                        thing: RawIdentifier("u2".to_owned())
                     }
                 }
             }
@@ -606,15 +600,11 @@ mod tests {
                         thing: RawVariableDeclaration {
                             name: Spanned {
                                 span: Span::from(((0, 1, 1), (1, 1, 2))),
-                                thing: RawIdentifier {
-                                    name: "x".to_owned()
-                                }
+                                thing: RawIdentifier("x".to_owned())
                             },
                             typ: Spanned {
                                 span: Span::from(((4, 1, 5), (6, 1, 7))),
-                                thing: RawIdentifier {
-                                    name: "u2".to_owned()
-                                }
+                                thing: RawIdentifier("u2".to_owned())
                             }
                         }
                     },
@@ -623,15 +613,11 @@ mod tests {
                         thing: RawVariableDeclaration {
                             name: Spanned {
                                 span: Span::from(((7, 1, 8), (8, 1, 9))),
-                                thing: RawIdentifier {
-                                    name: "y".to_owned()
-                                }
+                                thing: RawIdentifier("y".to_owned())
                             },
                             typ: Spanned {
                                 span: Span::from(((11, 1, 12), (13, 1, 14))),
-                                thing: RawIdentifier {
-                                    name: "u4".to_owned()
-                                }
+                                thing: RawIdentifier("u4".to_owned())
                             }
                         }
                     }
@@ -649,9 +635,7 @@ mod tests {
             thing: RawFunctionSignature {
                 name: Identifier {
                     span: Span::from(((3, 1, 4), (8, 1, 9))),
-                    thing: RawIdentifier {
-                        name: "add_1".to_owned(),
-                    },
+                    thing: RawIdentifier("add_1".to_owned()),
                 },
                 parameters: VariableDeclarationList {
                     span: Span::from(((9, 1, 10), (15, 1, 16))),
@@ -660,24 +644,18 @@ mod tests {
                         thing: RawVariableDeclaration {
                             name: Identifier {
                                 span: Span::from(((9, 1, 10), (10, 1, 11))),
-                                thing: RawIdentifier {
-                                    name: "x".to_owned(),
-                                },
+                                thing: RawIdentifier("x".to_owned()),
                             },
                             typ: Identifier {
                                 span: Span::from(((12, 1, 13), (15, 1, 16))),
-                                thing: RawIdentifier {
-                                    name: "u32".to_owned(),
-                                },
+                                thing: RawIdentifier("u32".to_owned()),
                             },
                         },
                     }],
                 },
                 result_type: Identifier {
                     span: Span::from(((20, 1, 21), (23, 1, 24))),
-                    thing: RawIdentifier {
-                        name: "u16".to_owned(),
-                    },
+                    thing: RawIdentifier("u16".to_owned()),
                 },
             },
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,6 +95,7 @@ fn parse_variable_declaration(input: ParseInput) -> ParseResult<VariableDeclarat
 /// Parses a comma-separated list of variable declarations, e.g., `x: u32, y: MyCustomType`.
 /// Note that a trailing comma will not be matched or consumed by this function.
 fn parse_parameter_list0(input: ParseInput) -> ParseResult<VariableDeclarationList> {
+    // TODO C++ DSLX allows a single trailing comma. Parse/allow that here.
     spanned(separated_list0(tag_ws(","), parse_variable_declaration))(input)
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -281,24 +281,6 @@ fn parse_unary_operator(input: ParseInput) -> ParseResult<UnaryOperator> {
     spanned(op).parse(input)
 }
 
-/// Parses unary and atomic expressions. E.g., `-u1:1`, `(u1:1 + u1:0)`
-fn parse_unary_atomic_expression(input: ParseInput) -> ParseResult<Expression> {
-    // this implementation follows the 'Top Down Operator Precedence' algorithm. See
-    // <https://btmc.substack.com/p/how-to-parse-expressions-easy> or <https://tdop.github.io/>
-    alt((
-        spanned(delimited(
-            tag("("),
-            parse_expression(None).map(|e| ParenthesizedExpression(e)),
-            tag_ws(")"),
-        )),
-        spanned(parse_let_expression),
-        spanned(tuple((parse_unary_operator, parse_unary_atomic_expression))),
-        spanned(parse_literal),
-        spanned(parse_identifier),
-    ))
-    .parse(input)
-}
-
 /// Parses a binary operator. E.g. `|`, `&`, etc.
 fn parse_binary_operator(input: ParseInput) -> ParseResult<BinaryOperator> {
     let op = alt((
@@ -348,6 +330,24 @@ fn parse_let_expression(
     let bound_expr = terminated(parse_expression(None), tag_ws(";"));
     let using_expr = opt(parse_expression(None));
     tuple((var_decl, bound_expr, using_expr)).parse(input)
+}
+
+/// Parses unary and atomic expressions. E.g., `-u1:1`, `(u1:1 + u1:0)`
+fn parse_unary_atomic_expression(input: ParseInput) -> ParseResult<Expression> {
+    // this implementation follows the 'Top Down Operator Precedence' algorithm. See
+    // <https://btmc.substack.com/p/how-to-parse-expressions-easy> or <https://tdop.github.io/>
+    alt((
+        spanned(delimited(
+            tag("("),
+            parse_expression(None).map(|e| ParenthesizedExpression(e)),
+            tag_ws(")"),
+        )),
+        spanned(parse_let_expression),
+        spanned(tuple((parse_unary_operator, parse_unary_atomic_expression))),
+        spanned(parse_literal),
+        spanned(parse_identifier),
+    ))
+    .parse(input)
 }
 
 /// Parses a binary operator and the expression that follows it, given the expression preceding

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -337,7 +337,9 @@ fn parse_let_expression(
     }
 
     // We avoid a recursive parsing implementation of nested let expressions to avoid stack
-    // overflows when fuzzing.
+    // overflows when fuzzing. Furthermore, we want to be as robust as possible, and not make
+    // assumptions about the user (i.e. not assume the user is going to limit their nesting of
+    // lets).
     let bindings = many1(spanned(parse_let_binding)).map(|xs| {
         let mut ys = NonEmpty::new(xs.first().unwrap().clone());
         ys.extend(xs.into_iter().skip(1));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,7 +90,7 @@ pub fn parse_identifier(input: ParseInput) -> ParseResult<Identifier> {
 }
 
 /// Parses a variable declaration, e.g., `x : u32`.
-fn parse_variable_declaration(input: ParseInput) -> ParseResult<VariableDeclaration> {
+fn parse_variable_declaration(input: ParseInput) -> ParseResult<VariableDecl> {
     spanned(tuple((
         parse_identifier,
         preceded(tag_ws(":"), parse_identifier),
@@ -100,7 +100,7 @@ fn parse_variable_declaration(input: ParseInput) -> ParseResult<VariableDeclarat
 
 /// Parses a comma-separated list of variable declarations, e.g., `x: u32, y: MyCustomType`.
 /// Note that a trailing comma will not be matched or consumed by this function.
-fn parse_parameter_list0(input: ParseInput) -> ParseResult<VariableDeclarationList> {
+fn parse_parameter_list0(input: ParseInput) -> ParseResult<VariableDeclList> {
     // TODO C++ DSLX allows a single trailing comma. Parse/allow that here.
     spanned(separated_list0(tag_ws(","), parse_variable_declaration))(input)
 }
@@ -649,9 +649,9 @@ mod tests {
                     span: Span::from(((3, 1, 4), (8, 1, 9))),
                     thing: RawIdentifier("add_1".to_owned()),
                 },
-                parameters: VariableDeclarationList {
+                parameters: VariableDeclList {
                     span: Span::from(((9, 1, 10), (15, 1, 16))),
-                    thing: vec![VariableDeclaration {
+                    thing: vec![VariableDecl {
                         span: Span::from(((9, 1, 10), (15, 1, 16))),
                         thing: RawVariableDeclaration {
                             name: Identifier {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -294,6 +294,7 @@ fn parse_unary_atomic_expression(input: ParseInput) -> ParseResult<Expression> {
         spanned(parse_let_expression),
         spanned(tuple((parse_unary_operator, parse_unary_atomic_expression))),
         spanned(parse_literal),
+        spanned(parse_identifier),
     ))
     .parse(input)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -497,7 +497,9 @@ mod tests {
                     unsafe { LocatedSpan::new_from_raw_offset(10, 1, "! ", (),) },
                     Spanned {
                         span: Span::from(((1, 1, 2), (10, 1, 11))),
-                        thing: RawIdentifier { name: "_foo23Bar" }
+                        thing: RawIdentifier {
+                            name: "_foo23Bar".to_owned()
+                        }
                     }
                 ),
             ),
@@ -524,11 +526,15 @@ mod tests {
                 thing: RawVariableDeclaration {
                     name: Spanned {
                         span: Span::from(((1, 1, 2), (2, 1, 3))),
-                        thing: RawIdentifier { name: "x" }
+                        thing: RawIdentifier {
+                            name: "x".to_owned()
+                        }
                     },
                     typ: Spanned {
                         span: Span::from(((5, 1, 6), (7, 1, 8))),
-                        thing: RawIdentifier { name: "u2" }
+                        thing: RawIdentifier {
+                            name: "u2".to_owned()
+                        }
                     }
                 }
             }
@@ -554,11 +560,15 @@ mod tests {
                         thing: RawVariableDeclaration {
                             name: Spanned {
                                 span: Span::from(((0, 1, 1), (1, 1, 2))),
-                                thing: RawIdentifier { name: "x" }
+                                thing: RawIdentifier {
+                                    name: "x".to_owned()
+                                }
                             },
                             typ: Spanned {
                                 span: Span::from(((4, 1, 5), (6, 1, 7))),
-                                thing: RawIdentifier { name: "u2" }
+                                thing: RawIdentifier {
+                                    name: "u2".to_owned()
+                                }
                             }
                         }
                     },
@@ -567,11 +577,15 @@ mod tests {
                         thing: RawVariableDeclaration {
                             name: Spanned {
                                 span: Span::from(((7, 1, 8), (8, 1, 9))),
-                                thing: RawIdentifier { name: "y" }
+                                thing: RawIdentifier {
+                                    name: "y".to_owned()
+                                }
                             },
                             typ: Spanned {
                                 span: Span::from(((11, 1, 12), (13, 1, 14))),
-                                thing: RawIdentifier { name: "u4" }
+                                thing: RawIdentifier {
+                                    name: "u4".to_owned()
+                                }
                             }
                         }
                     }
@@ -589,7 +603,9 @@ mod tests {
             thing: RawFunctionSignature {
                 name: Identifier {
                     span: Span::from(((3, 1, 4), (8, 1, 9))),
-                    thing: RawIdentifier { name: "add_1" },
+                    thing: RawIdentifier {
+                        name: "add_1".to_owned(),
+                    },
                 },
                 parameters: VariableDeclarationList {
                     span: Span::from(((9, 1, 10), (15, 1, 16))),
@@ -598,18 +614,24 @@ mod tests {
                         thing: RawVariableDeclaration {
                             name: Identifier {
                                 span: Span::from(((9, 1, 10), (10, 1, 11))),
-                                thing: RawIdentifier { name: "x" },
+                                thing: RawIdentifier {
+                                    name: "x".to_owned(),
+                                },
                             },
                             typ: Identifier {
                                 span: Span::from(((12, 1, 13), (15, 1, 16))),
-                                thing: RawIdentifier { name: "u32" },
+                                thing: RawIdentifier {
+                                    name: "u32".to_owned(),
+                                },
                             },
                         },
                     }],
                 },
                 result_type: Identifier {
                     span: Span::from(((20, 1, 21), (23, 1, 24))),
-                    thing: RawIdentifier { name: "u16" },
+                    thing: RawIdentifier {
+                        name: "u16".to_owned(),
+                    },
                 },
             },
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,8 +83,8 @@ pub fn parse_identifier(input: ParseInput) -> ParseResult<Identifier> {
     spanned(p).parse(input)
 }
 
-/// Parses a single param, e.g., `x: u32`.
-fn parse_param(input: ParseInput) -> ParseResult<VariableDeclaration> {
+/// Parses a variable declaration, e.g., `x : u32`.
+fn parse_variable_declaration(input: ParseInput) -> ParseResult<VariableDeclaration> {
     spanned(tuple((
         parse_identifier,
         preceded(tag_ws(":"), parse_identifier),
@@ -92,17 +92,17 @@ fn parse_param(input: ParseInput) -> ParseResult<VariableDeclaration> {
     .parse(input)
 }
 
-/// Parses a comma-separated list of params, e.g., `x: u32, y: MyCustomType`.
+/// Parses a comma-separated list of variable declarations, e.g., `x: u32, y: MyCustomType`.
 /// Note that a trailing comma will not be matched or consumed by this function.
-fn parse_param_list0(input: ParseInput) -> ParseResult<VariableDeclarationList> {
-    spanned(separated_list0(tag_ws(","), parse_param))(input)
+fn parse_parameter_list0(input: ParseInput) -> ParseResult<VariableDeclarationList> {
+    spanned(separated_list0(tag_ws(","), parse_variable_declaration))(input)
 }
 
 /// Parses a function signature, e.g.:
 /// `fn foo(a: u32, b: u64) -> uN[128]`
 fn parse_function_signature(input: ParseInput) -> ParseResult<FunctionSignature> {
     let name = preceded(tag_ws("fn"), parse_identifier);
-    let parameters = delimited(tag_ws("("), parse_param_list0, tag_ws(")"));
+    let parameters = delimited(tag_ws("("), parse_parameter_list0, tag_ws(")"));
     let ret_type = preceded(tag_ws("->"), parse_identifier);
     spanned(tuple((name, parameters, ret_type))).parse(input)
 }
@@ -511,8 +511,8 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_param() -> () {
-        let p = match parse_param(ParseInput::new(" x : u2 ")) {
+    fn test_parse_variable_declaration() -> () {
+        let p = match parse_variable_declaration(ParseInput::new(" x : u2 ")) {
             Ok(x) => x.1,
             Err(e) => {
                 eprintln!("Error: {}", e);
@@ -542,8 +542,8 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_param_list2() -> () {
-        let p = match parse_param_list0(ParseInput::new("x : u2,y : u4")) {
+    fn test_parse_parameter_list0() -> () {
+        let p = match parse_parameter_list0(ParseInput::new("x : u2,y : u4")) {
             Ok(x) => x.1,
             Err(e) => {
                 eprintln!("Error: {}", e);


### PR DESCRIPTION
- parse an Identifier (i.e. variable) as an Expression
- Identifier should own the str/String it holds. Now it does. Otherwise, do we really want our AST tied to the lifetime of the parsed source file?
- renamed some things because they're more general now
- make RawIdentifier hold a nameless field instead of naming the field `name`, because this was ridiculous: `bindings.first().thing.variable_declaration.thing.name.thing.name`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/xls-friends/dslx-rust/25)
<!-- Reviewable:end -->
