### PR TITLE
parse block expressions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [lib]
+# This is needed so that we can document Block expressions with a snippet of DSLX, which is not
+# valid Rust syntax, which pisses off doctest.
 doctest = false
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[lib]
+doctest = false
+
 [dependencies]
 nom = "7.1.3"
 nom_locate = "4.2.0"

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -375,10 +375,10 @@ pub struct RawLetBinding {
 }
 pub type LetBinding = Spanned<RawLetBinding>;
 
-// This struct exists to ensure that `From<Expression> for RawExpression` does not exist
-// (because instead we have `From<ParenthesizedExpression> for RawExpression`). The former was
-// bug prone: I was accidentally and unknowingly calling `from(Expression) -> RawExpression`.
-// Inside the `from` we will discard the ParenthesizedExpression 'wrapper'.
+/// This struct exists to ensure that `From<Expression> for RawExpression` does not exist
+/// (because instead we have `From<ParenthesizedExpression> for RawExpression`). The former was
+/// bug prone: I was accidentally and unknowingly calling `from(Expression) -> RawExpression`.
+/// Inside the `from` we will discard the ParenthesizedExpression 'wrapper'.
 #[derive(Debug, PartialEq, Clone)]
 pub struct ParenthesizedExpression(pub Expression);
 

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -406,7 +406,7 @@ pub enum RawExpression {
 
     /// Block expressions enable subordinate scopes to be defined. E.g.:
     ///
-    /// ```ignore
+    /// ```
     /// let a = {
     ///   let b = u32:1;
     ///   b + u32:3

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -401,6 +401,19 @@ pub enum RawExpression {
     /// a binary expression, e.g. `s1:1 + s1:0`
     Binary(Box<Expression>, BinaryOperator, Box<Expression>),
 
+    /// Block expressions enable subordinate scopes to be defined. E.g.:
+    ///
+    /// ```
+    /// let a = {
+    ///   let b = u32:1;
+    ///   b + u32:3
+    /// };
+    /// ```
+    ///
+    /// The value of a block expression is that of its last contained expression, or (), if a
+    /// final expression is omitted:
+    Block(Box<Expression>),
+
     /// 1 or more let expressions (i.e. the vector may be empty).
     ///
     /// Every binding is in scope in the bindings that come after it in the vector (i.e. a

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -382,6 +382,9 @@ pub type LetBinding = Spanned<RawLetBinding>;
 #[derive(Debug, PartialEq, Clone)]
 pub struct ParenthesizedExpression(pub Expression);
 
+/// This serves a similar purpose to ParenthesizedExpression.
+pub struct BlockExpression(pub Expression);
+
 /// An expression (i.e. a thing that can be evaluated), e.g. `s1:1 + s1:0`.
 #[derive(Debug, PartialEq, Clone)]
 pub enum RawExpression {
@@ -403,7 +406,7 @@ pub enum RawExpression {
 
     /// Block expressions enable subordinate scopes to be defined. E.g.:
     ///
-    /// ```
+    /// ```ignore
     /// let a = {
     ///   let b = u32:1;
     ///   b + u32:3
@@ -450,6 +453,12 @@ impl From<(UnaryOperator, Expression)> for RawExpression {
 impl From<(Expression, BinaryOperator, Expression)> for RawExpression {
     fn from((lhs, op, rhs): (Expression, BinaryOperator, Expression)) -> Self {
         RawExpression::Binary(Box::new(lhs), op, Box::new(rhs))
+    }
+}
+
+impl From<BlockExpression> for RawExpression {
+    fn from(BlockExpression(x): BlockExpression) -> Self {
+        RawExpression::Block(Box::new(x))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -258,15 +258,15 @@ fn parse_bit_type(input: ParseInput) -> ParseResult<BitType> {
 /// `s8:128`, `s8:-128`
 ///
 /// Uses the bit type to determine which kind of `RawInteger` to parse.
-fn parse_literal(input: ParseInput) -> ParseResult<Literal> {
-    fn parse(input: ParseInput) -> ParseResult<RawLiteral> {
+fn parse_literal<'a>(input: ParseInput<'a>) -> ParseResult<'a, Literal> {
+    let parse = |input: ParseInput<'a>| -> ParseResult<'a, RawLiteral> {
         let (input, bit_type) = terminated(parse_bit_type, tag_ws(":"))(input)?;
         let (rest, value): (ParseInput, Integer) = match bit_type.thing.signedness {
             Signedness::Signed => spanned(parse_signed_integer).parse(input),
             Signedness::Unsigned => spanned(parse_unsigned_integer).parse(input),
         }?;
         Ok((rest, RawLiteral { value, bit_type }))
-    }
+    };
 
     spanned(parse).parse(input)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -317,10 +317,10 @@ fn parse_binary_operator(input: ParseInput) -> ParseResult<BinaryOperator> {
 /// expression after the let (after all, what's the point of declaring a variable binding if
 /// you're never going to use the variable?), but not required. So the trailing expression is
 /// optional.
-fn parse_let_expression(
-    input: ParseInput,
-) -> ParseResult<(NonEmpty<LetBinding>, Option<Expression>)> {
-    fn parse_let_binding(input: ParseInput) -> ParseResult<RawLetBinding> {
+fn parse_let_expression<'a>(
+    input: ParseInput<'a>,
+) -> ParseResult<'a, (NonEmpty<LetBinding>, Option<Expression>)> {
+    let parse_let_binding = |input: ParseInput<'a>| -> ParseResult<'a, RawLetBinding> {
         let var_decl = delimited(
             // let must be followed by at least 1 whitespace
             tuple((tag_ws("let"), whitespace_exactly1)),
@@ -334,7 +334,7 @@ fn parse_let_expression(
                 value: Box::new(value),
             })
             .parse(input)
-    }
+    };
 
     // We avoid a recursive parsing implementation of nested let expressions to avoid stack
     // overflows when fuzzing. Furthermore, we want to be as robust as possible, and not make

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -360,6 +360,11 @@ fn parse_unary_atomic_expression(input: ParseInput) -> ParseResult<Expression> {
             parse_expression(None).map(ParenthesizedExpression),
             tag_ws(")"),
         )),
+        spanned(delimited(
+            tag("{"),
+            parse_expression(None).map(BlockExpression),
+            tag_ws("}"),
+        )),
         spanned(parse_let_expression),
         spanned(tuple((parse_unary_operator, parse_unary_atomic_expression))),
         spanned(parse_literal),


### PR DESCRIPTION
- and test it
- disable doc tests so my documentation can provide DSLX examples
- misc: make two inner functions into closures so they don't appear in the Outline view
