### PR TITLE
Parse range expressions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -62,7 +62,4 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: clippy
-          # TODO disallow dead code eventually, when all leaf functions are being used by root
-          # functions
-          # elided_named_lifetimes are allowed, for brevity.
-          args: -- -D warnings -A dead_code -A elided_named_lifetimes
+          args: -- -D warnings

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -221,6 +221,7 @@ pub struct ParenthesizedExpression(pub Expression);
 /// <https://google.github.io/xls/dslx_reference/#shift-expressions>
 /// <https://google.github.io/xls/dslx_reference/#comparison-expressions>
 /// <https://google.github.io/xls/dslx_reference/#concat-expression>
+/// <https://google.github.io/xls/dslx_reference/#iterable-expression>
 ///
 /// They are ordered from highest precedence to lowest, and grouped when same precedence.
 #[derive(Debug, PartialEq, Clone, Copy)]
@@ -268,7 +269,10 @@ pub enum RawBinaryOperator {
     /// `||`, boolean or
     BooleanOr,
 
-    /// `..`, creates a range expression, e.g. `u32:0 .. u32:8`
+    /// `..`, creates a range expression, e.g. `u32:0 .. u32:8`, which expands to the integral
+    /// values [0, 8). Currently, only the Rust RangeExpr form is supported
+    /// (https://doc.rust-lang.org/reference/expressions/range-expr.html), i.e., the 5 other
+    /// variants are not implemented (RangeFromExpr, RangeToExpr, etc.).
     Range,
 }
 

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -446,6 +446,9 @@ pub enum RawExpression {
     /// binding is lexically scoped). The final expression, if present (and we expect it to
     /// exist most of the time, otherwise, why bother with an if expression), can use all the
     /// bindings. When absent, the value of the let expression is `()`.
+    // TODO FIXME let is not an expression; it's a statement. It's not even an Expr in DSLX C++
+    // code:
+    // https://github.com/google/xls/blob/aad0d13240cc3ad413a03cc292e9d3acf1fb79c6/xls/dslx/frontend/parser.cc#L2452
     Let(NonEmpty<LetBinding>, Option<Box<Expression>>),
 
     /// 1 or more `if` and `else if` expressions, followed by the final `else`'s alternate

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -402,7 +402,7 @@ fn parse_unary_atomic_expression(input: ParseInput) -> ParseResult<Expression> {
             parse_expression(None).map(BlockExpression),
             tag_ws("}"),
         )),
-        spanned(parse_let_expression),
+        spanned(parse_let_expression), // TODO FIXME let is not an expression
         spanned(parse_ifelse_expression),
         spanned(tuple((parse_unary_operator, parse_unary_atomic_expression))),
         spanned(parse_literal),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -530,6 +530,7 @@ fn parse_expression<'a>(
     }
 }
 
+// TODO PR suggestion: move all tests to own file
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -389,39 +389,6 @@ fn parse_ifelse_expression<'a>(
     tuple((ifelses, alternate)).parse(input)
 }
 
-// TODO delete this function. Save (some? none?) of the comment.
-/// Parses an expression that produces a 'range', that is: `expr .. expr` expression. E.g.
-/// `u32:0..u32:8`
-fn parse_range_expression<'a>(input: ParseInput<'a>) -> () {
-    // XLS parser does
-    // https://github.com/google/xls/blob/main/xls/dslx/frontend/parser.cc#L555
-    // ParseLogicalOrExpression
-    // match `..`
-    // ParseLogicalOrExpression
-    // It seems that ParseLogicalOrExpression will match
-    // logical or, logical and, one of the comparison expressions, bitwise or, bitwise xor,
-    // bitwise and, weak arithmetic, strong arithmetic, ParseCastAsExpression
-    // https://github.com/google/xls/blob/main/xls/dslx/frontend/parser.cc#L2005 calls ParseTerm
-    // which calls ParseTermLhs
-    // https://github.com/google/xls/blob/main/xls/dslx/frontend/parser.cc#L1541
-    // ParseTermLhs is complex, but it seems equivalent to parse_unary_atomic_expression. For
-    // example, it matches identifiers, parenthesized expressions, unary expressions (negate
-    // and invert), numeric literals, `if` expressions, `match` expression, etc.
-    // However! ParseTermLhs does not seem to accept `let` expr or block expr (`{ } `).
-
-    // https://github.com/google/xls/blob/aad0d13240cc3ad413a03cc292e9d3acf1fb79c6/xls/dslx/frontend/parser.cc#L524
-    // ParseExpression is illustrative. It accepts:
-    // for, unroll for, channel, spawn, brace, and ParseConditionalExpression
-
-    // So it seems like I should treat `..` as a type of binary expression, a range expression.
-    // What is its precedence?
-    // Parser::ParseConditionalExpression calls ParseRangeExpression when there is no leading
-    // `if` keyword.
-    // ParseRangeExpression calls ParseLogicalOrExpression, saving the Expr. If the next token
-    // is `..`, then ParseLogicalOrExpression is called again, and a Range Expr is returned. So
-    // I think we'd say that the `..` has lower precedence than logical or.
-}
-
 /// Parses unary and atomic expressions. E.g., `-u1:1`, `(u1:1 + u1:0)`
 fn parse_unary_atomic_expression(input: ParseInput) -> ParseResult<Expression> {
     // this implementation follows the 'Top Down Operator Precedence' algorithm. See

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@
 // TODO one day when all functions in this file are used, delete below. For now, we prefer to
 // avoid spammy Github Actions notes about unused functions.
 #![allow(dead_code)]
-// We prerfer brevity.
+// We prefer brevity.
 #![allow(elided_named_lifetimes)]
 pub mod ast;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -439,14 +439,12 @@ fn parse_infix_expression<'a>(
             ))
         })
         .map(|(left, op, right)| {
-            let thing = RawExpression::from((left.clone(), op, right.clone()));
-            Spanned {
-                span: Span {
-                    start: left.span.start,
-                    end: right.span.end,
-                },
-                thing,
-            }
+            let span = Span {
+                start: left.span.start.clone(),
+                end: right.span.end.clone(),
+            };
+            let thing = RawExpression::from((left, op, right));
+            Spanned { span, thing }
         })
         .parse(input)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -387,6 +387,39 @@ fn parse_ifelse_expression<'a>(
     tuple((ifelses, alternate)).parse(input)
 }
 
+// TODO delete this function. Save (some? none?) of the comment.
+/// Parses an expression that produces a 'range', that is: `expr .. expr` expression. E.g.
+/// `u32:0..u32:8`
+fn parse_range_expression<'a>(input: ParseInput<'a>) -> () {
+    // XLS parser does
+    // https://github.com/google/xls/blob/main/xls/dslx/frontend/parser.cc#L555
+    // ParseLogicalOrExpression
+    // match `..`
+    // ParseLogicalOrExpression
+    // It seems that ParseLogicalOrExpression will match
+    // logical or, logical and, one of the comparison expressions, bitwise or, bitwise xor,
+    // bitwise and, weak arithmetic, strong arithmetic, ParseCastAsExpression
+    // https://github.com/google/xls/blob/main/xls/dslx/frontend/parser.cc#L2005 calls ParseTerm
+    // which calls ParseTermLhs
+    // https://github.com/google/xls/blob/main/xls/dslx/frontend/parser.cc#L1541
+    // ParseTermLhs is complex, but it seems equivalent to parse_unary_atomic_expression. For
+    // example, it matches identifiers, parenthesized expressions, unary expressions (negate
+    // and invert), numeric literals, `if` expressions, `match` expression, etc.
+    // However! ParseTermLhs does not seem to accept `let` expr or block expr (`{ } `).
+
+    // https://github.com/google/xls/blob/aad0d13240cc3ad413a03cc292e9d3acf1fb79c6/xls/dslx/frontend/parser.cc#L524
+    // ParseExpression is illustrative. It accepts:
+    // for, unroll for, channel, spawn, brace, and ParseConditionalExpression
+
+    // So it seems like I should treat `..` as a type of binary expression, a range expression.
+    // What is its precedence?
+    // Parser::ParseConditionalExpression calls ParseRangeExpression when there is no leading
+    // `if` keyword.
+    // ParseRangeExpression calls ParseLogicalOrExpression, saving the Expr. If the next token
+    // is `..`, then ParseLogicalOrExpression is called again, and a Range Expr is returned. So
+    // I think we'd say that the `..` has lower precedence than logical or.
+}
+
 /// Parses unary and atomic expressions. E.g., `-u1:1`, `(u1:1 + u1:0)`
 fn parse_unary_atomic_expression(input: ParseInput) -> ParseResult<Expression> {
     // this implementation follows the 'Top Down Operator Precedence' algorithm. See

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,8 @@
 // TODO one day when all functions in this file are used, delete below. For now, we prefer to
 // avoid spammy Github Actions notes about unused functions.
 #![allow(dead_code)]
+// We prerfer brevity.
+#![allow(elided_named_lifetimes)]
 pub mod ast;
 
 use ast::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -306,6 +306,8 @@ fn parse_binary_operator(input: ParseInput) -> ParseResult<BinaryOperator> {
         value(RawBinaryOperator::Greater, tag(">")),
         value(RawBinaryOperator::LessOrEqual, tag("<=")),
         value(RawBinaryOperator::Less, tag("<")),
+        // other
+        value(RawBinaryOperator::Range, tag("..")),
     ));
     spanned(op).parse(input)
 }
@@ -539,7 +541,7 @@ mod tests {
     fn expression_is_literal(x: Expression) -> RawLiteral {
         match x.thing {
             RawExpression::Literal(Spanned { span: _, thing }) => thing,
-            _ => panic!("wasn't Literal expression"),
+            e => panic!("wasn't Literal expression: {:?}", e),
         }
     }
 
@@ -1516,6 +1518,14 @@ mod tests {
             let _ = expression_is_literal(*lhs);
             let _ = expression_is_literal(*rhs);
         }
+
+        // range operator is lower precedence than boolean or
+        first_then(
+            "u1:0 || u1:0 .. u1:1",
+            RawBinaryOperator::BooleanOr,
+            RawBinaryOperator::Range,
+            FirstsLocation::LeftHandSide,
+        );
     }
 
     // Tests parsing of expressions containing (), asserts that


### PR DESCRIPTION
They are parsed as the lowest precedence binary expression (i.e. `..` has the lowest precedence of all binary operators), same as the C++ parser does. See https://github.com/google/xls/blob/ff3e244a2288429f01d91b2deed694a188bd2e93/xls/dslx/frontend/parser.cc#L556 where the logic is `ParseLogicalOrExpression`, parse `..`, then `ParseLogicalOrExpression`. That is, a logical or expression binds more tightly (has higher precedence) than a range expression. Furthermore, a range expression is a binary operator, because there are two expressions on either side of `..`.

So this just boils down to adding `..` as the lowest precedence of all binary operators. Test.

#### Misc.
* do less cloning in `parse_infix_expression`
* add a few TODOs

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/xls-friends/dslx-rust/28)
<!-- Reviewable:end -->
