### PR TITLE
Removes unneeded (and cargo-make-complain-y) #feature decl.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,8 +3,6 @@
 //! Full language defined here: <https://google.github.io/xls/dslx_reference/>
 //! Currently a spooky scary skeleton, but actively being built out.
 //!
-//! At present, the _only_ entry point is `parse_function_signature`, taking in an ast::ParseInput.
-#![feature(assert_matches)]
 // TODO one day when all functions in this file are used, delete below. For now, we prefer to
 // avoid spammy Github Actions notes about unused functions.
 #![allow(dead_code)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 //! Full language defined here: <https://google.github.io/xls/dslx_reference/>
 //! Currently a spooky scary skeleton, but actively being built out.
 //!
+//! At present, the _only_ entry point is `parse_function_signature`, taking in an ast::ParseInput.
 // TODO one day when all functions in this file are used, delete below. For now, we prefer to
 // avoid spammy Github Actions notes about unused functions.
 #![allow(dead_code)]


### PR DESCRIPTION
I *think* this is good/right? A) I don't think we're actually using `assert_matches`, and B) it might be part of `std` now?